### PR TITLE
Dictionary objects must match

### DIFF
--- a/trellis/group_vars/development/vault.yml
+++ b/trellis/group_vars/development/vault.yml
@@ -7,7 +7,7 @@ vault_sudoer_passwords:
 
 # Variables to accompany `group_vars/development/wordpress_sites.yml`
 vault_wordpress_sites:
-  manorfarm-shop.dev:
+  manorfarm-shop:
     admin_password: oFFi85^blu
     env:
       db_password: oFFi85

--- a/trellis/group_vars/development/wordpress_sites.yml
+++ b/trellis/group_vars/development/wordpress_sites.yml
@@ -1,6 +1,6 @@
 # Documentation: https://roots.io/trellis/docs/local-development-setup/
 wordpress_sites:
-  BLU:
+  manorfarm-shop:
     site_hosts:
       - manorfarm-shop.dev
     local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)


### PR DESCRIPTION
The wordpress sites and vault dictionary objects must match.